### PR TITLE
Allow to configure errors ignoring

### DIFF
--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -92,47 +92,29 @@ defmodule NewRelic.Config do
   Check if the error must be ignored by reporting system.
 
   You can specify a comma-delimited list of error modules that the agent should 
-  ignore by the key `NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS`:
-
-  ```
-  export NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS="Ecto.NoResultsError,MyApp.MustBeIgnored"
-  ```
-
-  Or by Application:
+  ignore by the Application config:
 
   ```
   config :new_relic_agent, 
     error_collector_ignore_errors: [Ecto.NoResultsError, MyApp.MustBeIgnored]
   ```
   """
-  def ignored_error?(%{__struct__: _} = error) do 
-    error.__struct__ in ignored_errors()
+  def ignored_error?(%{__struct__: error}) do 
+    error in ignored_errors()
   end
-  def ignored_error?(_), do: false
+  
+  def ignored_error?(error) when is_binary(error) do
+    Module.safe_concat("Elixir", error) in ignored_errors()
+  rescue
+    ArgumentError -> false
+  end
+
+  def ignored_error?(_) do 
+    false
+  end
 
   defp ignored_errors do
-    errors_env = 
-      System.get_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS")
-      |> parse_env_errors()
-
-    errors_list = Application.get_env(:new_relic_agent, :error_collector_ignore_errors, [])
-
-    Enum.concat(errors_env, errors_list)
-  end
-
-  defp parse_env_errors(nil), do: []
-  defp parse_env_errors(arg) do
-    arg
-    |> String.split(",")
-    |> Stream.map(&String.trim/1)
-    |> Stream.map(&parse_env_error/1)
-    |> Enum.filter(&(!is_nil(&1)))
-  end
-
-  defp parse_env_error(error) do
-    Module.safe_concat("Elixir", error)
-  rescue
-    ArgumentError -> nil
+    Application.get_env(:new_relic_agent, :error_collector_ignore_errors, [])
   end
 
   @doc """

--- a/lib/new_relic/config.ex
+++ b/lib/new_relic/config.ex
@@ -99,17 +99,17 @@ defmodule NewRelic.Config do
     error_collector_ignore_errors: [Ecto.NoResultsError, MyApp.MustBeIgnored]
   ```
   """
-  def ignored_error?(%{__struct__: error}) do 
+  def ignored_error?(%{__struct__: error}) do
     error in ignored_errors()
   end
-  
+
   def ignored_error?(error) when is_binary(error) do
     Module.safe_concat("Elixir", error) in ignored_errors()
   rescue
     ArgumentError -> false
   end
 
-  def ignored_error?(_) do 
+  def ignored_error?(_) do
     false
   end
 

--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -1,58 +1,63 @@
 defmodule NewRelic.Error.Reporter do
-  alias NewRelic.Util
+  alias NewRelic.{Config, Util}
   alias NewRelic.Harvest.Collector
 
   def report_transaction_error(report) do
     {kind, exception, stacktrace} = parse_error_info(report[:error_info])
-    process_name = parse_process_name(report[:registered_name], stacktrace)
+    
+    unless Config.ignored_error?(exception) do
+      process_name = parse_process_name(report[:registered_name], stacktrace)
 
-    NewRelic.Transaction.Reporter.set_transaction_error(report[:pid], %{
-      kind: kind,
-      process: process_name,
-      reason: exception,
-      stack: stacktrace
-    })
+      NewRelic.Transaction.Reporter.set_transaction_error(report[:pid], %{
+        kind: kind,
+        process: process_name,
+        reason: exception,
+        stack: stacktrace
+      })
+    end
   end
 
   def report_process_error(report) do
     {kind, exception, stacktrace} = parse_error_info(report[:error_info])
 
-    {exception_type, exception_reason, exception_stacktrace} =
-      Util.Error.normalize(kind, exception, stacktrace, report[:initial_call])
+    unless Config.ignored_error?(exception) do
+      {exception_type, exception_reason, exception_stacktrace} =
+        Util.Error.normalize(kind, exception, stacktrace, report[:initial_call])
 
-    process_name = parse_process_name(report[:registered_name], stacktrace)
-    expected = parse_error_expected(exception)
-    automatic_attributes = NewRelic.Config.automatic_attributes()
+      process_name = parse_process_name(report[:registered_name], stacktrace)
+      expected = parse_error_expected(exception)
+      automatic_attributes = NewRelic.Config.automatic_attributes()
 
-    Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
-      timestamp: System.system_time(:millisecond) / 1_000,
-      error_type: exception_type,
-      message: exception_reason,
-      expected: expected,
-      stack_trace: exception_stacktrace,
-      transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name
-        })
-    })
+      Collector.ErrorTrace.Harvester.report_error(%NewRelic.Error.Trace{
+        timestamp: System.system_time(:millisecond) / 1_000,
+        error_type: exception_type,
+        message: exception_reason,
+        expected: expected,
+        stack_trace: exception_stacktrace,
+        transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
+        user_attributes:
+          Map.merge(automatic_attributes, %{
+            process: process_name
+          })
+      })
 
-    Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
-      timestamp: System.system_time(:millisecond) / 1_000,
-      error_class: exception_type,
-      error_message: exception_reason,
-      expected: expected,
-      transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
-      user_attributes:
-        Map.merge(automatic_attributes, %{
-          process: process_name,
-          stacktrace: Enum.join(exception_stacktrace, "\n")
-        })
-    })
+      Collector.TransactionErrorEvent.Harvester.report_error(%NewRelic.Error.Event{
+        timestamp: System.system_time(:millisecond) / 1_000,
+        error_class: exception_type,
+        error_message: exception_reason,
+        expected: expected,
+        transaction_name: "OtherTransaction/Elixir/ElixirProcess//#{process_name}",
+        user_attributes:
+          Map.merge(automatic_attributes, %{
+            process: process_name,
+            stacktrace: Enum.join(exception_stacktrace, "\n")
+          })
+      })
 
-    unless expected do
-      NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
-      NewRelic.report_metric(:error, error_count: 1)
+      unless expected do
+        NewRelic.report_metric({:supportability, :error_event}, error_count: 1)
+        NewRelic.report_metric(:error, error_count: 1)
+      end
     end
   end
 

--- a/lib/new_relic/error/reporter.ex
+++ b/lib/new_relic/error/reporter.ex
@@ -4,7 +4,7 @@ defmodule NewRelic.Error.Reporter do
 
   def report_transaction_error(report) do
     {kind, exception, stacktrace} = parse_error_info(report[:error_info])
-    
+
     unless Config.ignored_error?(exception) do
       process_name = parse_process_name(report[:registered_name], stacktrace)
 

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -15,16 +15,18 @@ defmodule NewRelic.Transaction.Complete do
       |> transform_name_attrs
       |> transform_time_attrs
       |> extract_transaction_info(pid)
-
-    report_transaction_event(tx_attrs)
-    report_transaction_trace(tx_attrs, tx_segments)
-    report_transaction_error_event(tx_attrs, tx_error)
-    report_transaction_metric(tx_attrs)
-    report_transaction_metrics(tx_attrs, tx_metrics)
-    report_aggregate(tx_attrs)
-    report_caller_metric(tx_attrs)
-    report_apdex_metric(apdex)
-    report_span_events(span_events)
+    
+    unless ignore_transaction?(tx_attrs) do
+      report_transaction_event(tx_attrs)
+      report_transaction_trace(tx_attrs, tx_segments)
+      report_transaction_error_event(tx_attrs, tx_error)
+      report_transaction_metric(tx_attrs)
+      report_transaction_metrics(tx_attrs, tx_metrics)
+      report_aggregate(tx_attrs)
+      report_caller_metric(tx_attrs)
+      report_apdex_metric(apdex)
+      report_span_events(span_events)
+    end
   end
 
   def run(tx_attrs, _pid) do
@@ -520,4 +522,12 @@ defmodule NewRelic.Transaction.Complete do
 
   defp parse_error_expected(%{expected: true}), do: true
   defp parse_error_expected(_), do: false
+
+  defp ignore_transaction?(%{error: true, error_reason: reason}) do
+    [[_, error]] = Regex.scan(~r{^\%(.+)\{}, reason)
+
+    NewRelic.Config.ignored_error?(error)
+  end
+
+  defp ignore_transaction?(_), do: false
 end

--- a/lib/new_relic/transaction/complete.ex
+++ b/lib/new_relic/transaction/complete.ex
@@ -15,7 +15,7 @@ defmodule NewRelic.Transaction.Complete do
       |> transform_name_attrs
       |> transform_time_attrs
       |> extract_transaction_info(pid)
-    
+
     unless ignore_transaction?(tx_attrs) do
       report_transaction_event(tx_attrs)
       report_transaction_trace(tx_attrs, tx_segments)

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -59,22 +59,6 @@ defmodule ConfigTest do
     System.delete_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED")
   end
 
-  test "Can configure errors to be ignored via ENV" do
-    System.put_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS", "RuntimeError")
-    
-    assert NewRelic.Config.ignored_error?(%RuntimeError{})
-    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
-
-    System.put_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS", "RuntimeError,ArithmeticError")
-    assert NewRelic.Config.ignored_error?(%RuntimeError{})
-    assert NewRelic.Config.ignored_error?(%ArithmeticError{})
-
-    System.delete_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS")
-
-    refute NewRelic.Config.ignored_error?(%RuntimeError{})
-    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
-  end
-
   test "Can configure errors to be ignored via Application" do
     Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [RuntimeError])
     

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -61,11 +61,15 @@ defmodule ConfigTest do
 
   test "Can configure errors to be ignored via Application" do
     Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [RuntimeError])
-    
+
     assert NewRelic.Config.ignored_error?(%RuntimeError{})
     refute NewRelic.Config.ignored_error?(%ArithmeticError{})
 
-    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [RuntimeError, ArithmeticError])
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [
+      RuntimeError,
+      ArithmeticError
+    ])
+
     assert NewRelic.Config.ignored_error?(%RuntimeError{})
     assert NewRelic.Config.ignored_error?(%ArithmeticError{})
 

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -59,6 +59,37 @@ defmodule ConfigTest do
     System.delete_env("NEW_RELIC_ERROR_COLLECTOR_ENABLED")
   end
 
+  test "Can configure errors to be ignored via ENV" do
+    System.put_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS", "RuntimeError")
+    
+    assert NewRelic.Config.ignored_error?(%RuntimeError{})
+    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
+
+    System.put_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS", "RuntimeError,ArithmeticError")
+    assert NewRelic.Config.ignored_error?(%RuntimeError{})
+    assert NewRelic.Config.ignored_error?(%ArithmeticError{})
+
+    System.delete_env("NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS")
+
+    refute NewRelic.Config.ignored_error?(%RuntimeError{})
+    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
+  end
+
+  test "Can configure errors to be ignored via Application" do
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [RuntimeError])
+    
+    assert NewRelic.Config.ignored_error?(%RuntimeError{})
+    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
+
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [RuntimeError, ArithmeticError])
+    assert NewRelic.Config.ignored_error?(%RuntimeError{})
+    assert NewRelic.Config.ignored_error?(%ArithmeticError{})
+
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [])
+    refute NewRelic.Config.ignored_error?(%RuntimeError{})
+    refute NewRelic.Config.ignored_error?(%ArithmeticError{})
+  end
+
   test "Parse multiple app names" do
     System.put_env("NEW_RELIC_APP_NAME", "One Name; Two Names ")
     assert "Two Names" in NewRelic.Config.app_name()

--- a/test/error_test.exs
+++ b/test/error_test.exs
@@ -130,4 +130,18 @@ defmodule ErrorTest do
              intrinsic[:"error.class"] == "File.Error"
            end)
   end
+
+  test "ignore errors by config" do
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [ArithmeticError])
+    TestHelper.restart_harvest_cycle(Collector.TransactionErrorEvent.HarvestCycle)
+
+    :proc_lib.spawn(fn ->
+      raise ArithmeticError
+    end)
+
+    :timer.sleep(100)
+
+    events = TestHelper.gather_harvest(Collector.TransactionErrorEvent.Harvester)
+    assert length(events) == 0
+  end
 end

--- a/test/error_trace_test.exs
+++ b/test/error_trace_test.exs
@@ -158,4 +158,18 @@ defmodule ErrorTraceTest do
     traces = TestHelper.gather_harvest(Collector.ErrorTrace.Harvester)
     assert length(traces) == 1
   end
+
+  test "doesn't report an error if it must be ignored" do
+    Application.put_env(:new_relic_agent, :error_collector_ignore_errors, [ArithmeticError])
+    TestHelper.restart_harvest_cycle(Collector.ErrorTrace.HarvestCycle)
+
+    :proc_lib.spawn(fn ->
+      raise ArithmeticError
+    end)
+
+    :timer.sleep(100)
+
+    traces = TestHelper.gather_harvest(Collector.ErrorTrace.Harvester)
+    assert length(traces) == 0
+  end
 end


### PR DESCRIPTION
Implement errors ignoring on NewRelic agent based on https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration#error_collector-ignore_errors feature.